### PR TITLE
Added the remind command to the bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,11 +10,16 @@ activity = discord.Streaming(name="xda/help", url="https://www.youtube.com/watch
 client = commands.Bot(command_prefix = "xda/", activity = activity, intents=discord.Intents.all())
 client.remove_command("help"); slash = SlashCommand(client, sync_commands=True); num = [1, 2, 3, 4, 5]
 
+guild_ids = os.environ["SLASH_COMMAND_GUILD_IDS"]
+guild_ids = guild_ids.split(" ")
+
+guild_ids = [int(guild_id) for guild_id in guild_ids]
+
 
 ###########################################################
 """Ping commands"""
 @slash.slash(name="ping", description="Just a test command",
-         guild_ids=[868353576160854116, 422814981520621569])
+         guild_ids=guild_ids)
 async def _ping(ctx): 
     await ctx.send(f"Pong! {round(client.latency*1000)}ms")
         

--- a/cogs/main.py
+++ b/cogs/main.py
@@ -16,8 +16,17 @@ class Main(commands.Cog):
  _>  </ // / __ |  / // / (_-</ __/ _ \/ __/ _  / / _  / -_) / _ \/ -_) __/
 /_/|_/____/_/ |_| /____/_/___/\__/\___/_/  \_,_/ /_//_/\__/_/ .__/\__/_/   
                                                            /_/            """)
-        print(f"\nStarted at {datetime.now().strftime('%I:%m %p')}\nBot Creator(s): NullCode#1337; Nabsi#4017; justAHuman#1202\n\nErrors:")
+        print(f"\nStarted at {datetime.now().strftime('%I:%m %p')}\nBot Creator(s): NullCode#1337; Nabsi#4017; justAHuman#1202\n\n")
     
+        guild_ids_of_guilds_bot_is_in = []
+
+        for guild in self.client.guilds:
+            guild_ids_of_guilds_bot_is_in.append(guild.id)
+
+        print("Ids of servers the bot is in:\n", guild_ids_of_guilds_bot_is_in)
+        print("Errors:")
+
+
     @commands.command(aliases=['help', 'helpmenu'])
     async def menu(self, ctx):
         embed = discord.Embed(title = "__Commands List:__", color = 0x301c24)

--- a/cogs/main.py
+++ b/cogs/main.py
@@ -35,6 +35,9 @@ class Main(commands.Cog):
         embed.add_field(name = "xda/forum {question}", value = "Searches XDA Forums for your string", inline = False)
         embed.add_field(name = "xda/magisk", value = "Sends everything Magisk related", inline = False)
         embed.add_field(name = "xda/about", value = "About the bot and it's creator :D", inline = False)
+        embed.add_field(name = "xda/ping", value = "Pong!", inline = False)
+        embed.add_field(name = "xda/remind", value = "Reminds you after x seconds with a message\nUsage: `xda/remind <time_in_seconds> <message>`", inline = False)
+        embed.add_field(name = "xda/help", value = "Shows this message", inline = False)
         await ctx.send(embed = embed)
     
     @commands.command()

--- a/cogs/remind.py
+++ b/cogs/remind.py
@@ -1,0 +1,17 @@
+import discord
+from discord.ext import commands
+import asyncio
+
+class Remind(commands.Cog):
+    def __init__(self, client):
+        self.client = client
+
+    @commands.command()
+    async def remind(self, ctx, time, *msg):
+        """Reminds you of something after a certain amount of time"""
+        await ctx.send("I'll remind you of that in {} seconds".format(time))
+        await asyncio.sleep(int(time))
+        await ctx.send(" ".join(msg))
+
+def setup(client):
+    client.add_cog(Remind(client))

--- a/cogs/slash.py
+++ b/cogs/slash.py
@@ -4,9 +4,18 @@ from discord_slash import SlashCommand
 from discord_slash import SlashContext
 from discord_slash import cog_ext
 from time import time
+import os
+from dotenv import load_dotenv
+load_dotenv()
 
 bot = commands.Bot(command_prefix="xda/", intents=discord.Intents.all())
 slash = SlashCommand(bot, sync_commands=True); startTime = time()
+
+guild_ids = os.environ["SLASH_COMMAND_GUILD_IDS"]
+guild_ids = guild_ids.split(" ")
+
+guild_ids = [int(guild_id) for guild_id in guild_ids]
+
 
 class Slashmain(commands.Cog):
     def __init__(self, client):
@@ -14,7 +23,7 @@ class Slashmain(commands.Cog):
         
     @cog_ext.cog_slash(name="about", 
              description="Some statistics about the bot",
-             guild_ids=[868353576160854116, 422814981520621569])
+             guild_ids=guild_ids)
     async def _about(self, ctx: SlashContext): 
         uptime_s = int(round(time() - startTime))
         if uptime_s > 86400:

--- a/cogs/slashforum.py
+++ b/cogs/slashforum.py
@@ -2,9 +2,16 @@ import discord
 from discord.ext import commands
 from discord_slash import SlashCommand; from discord_slash import SlashContext; from discord_slash import cog_ext
 import googlesearch
+from dotenv import load_dotenv
+import os
+load_dotenv()
 
 num = [1, 2, 3, 4, 5]
 bot = commands.Bot(command_prefix="xda/", intents=discord.Intents.all()); slash = SlashCommand(bot, sync_commands=True)
+guild_ids = os.environ["SLASH_COMMAND_GUILD_IDS"]
+guild_ids = guild_ids.split(" ")
+
+guild_ids = [int(guild_id) for guild_id in guild_ids]
 
 class SlashForum(commands.Cog):
     def __init__(self, client):
@@ -12,7 +19,7 @@ class SlashForum(commands.Cog):
  
     @cog_ext.cog_slash(name="google", 
              description="Searches Google for you",
-             guild_ids=[868353576160854116, 422814981520621569])
+             guild_ids=guild_ids)
     async def _google(self, ctx: SlashContext, search_string):
         await ctx.defer()
 
@@ -26,7 +33,7 @@ class SlashForum(commands.Cog):
 
     @cog_ext.cog_slash(name="forum", 
              description="Searches XDA Forums for you",
-             guild_ids=[868353576160854116, 422814981520621569])
+             guild_ids=guild_ids)
     async def _forum(self, ctx, search_string):
         serch_a = search_string; await ctx.defer()
         serch_a += " site:forum.xda-developers.com"


### PR DESCRIPTION
I added the remind command to the bot that can be invoked with `xda/remind` and takes 2 arguments, the time (in seconds) and the message. This will be worked upon later on to include better time settings. I also moved the guild_ids to an environment variable with the format of `SLASH_COMMAND_GUILD_IDS="<guild1_id> <guild2_id> ..."`. I am also printing out the guild ids for every guild the bot is in once the bot is ready.